### PR TITLE
Not-smart widgets

### DIFF
--- a/lib/todo_page.dart
+++ b/lib/todo_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:todo_app/local_data_source.dart';
 import 'package:todo_app/todo_item.dart';
+import 'package:todo_app/widgets/actions/add_floating_action_button.dart';
 import 'package:todo_app/widgets/actions/copy_action.dart';
 import 'package:todo_app/widgets/actions/delete_all_action.dart';
 import 'package:todo_app/widgets/actions/sort_action.dart';
@@ -60,7 +61,6 @@ class _TodoPageState extends State<TodoPage> {
     );
   }
 
-  //Não vale a pena transformar esse componente em um not-smart widget
   Widget _buildSortButton() {
     return SortAction(
       onPressed: () {
@@ -79,7 +79,6 @@ class _TodoPageState extends State<TodoPage> {
     );
   }
 
-  //Não vale a pena transformar esse componente em um not-smart widget
   Widget _buildCopyMethod() {
     return CopyAction(
       onPressed: () async {
@@ -98,7 +97,6 @@ class _TodoPageState extends State<TodoPage> {
     );
   }
 
-  //Não vale a pena transformar esse componente em um not-smart widget
   Widget _buildDeleteAllButton() {
     return DeleteAllAction(
       onPressed: () {
@@ -143,6 +141,7 @@ class _TodoPageState extends State<TodoPage> {
     final focusNode = lastItem ? FocusNode() : null;
     if (lastItem) _lastFocusNode = focusNode;
     return TodoItemWidget(
+      key: ValueKey(todoItem),
       todoItem: todoItem,
       focusNode: focusNode,
       onDismissed: (direction) => _onDismissed(index, context, todoItem),
@@ -207,9 +206,8 @@ class _TodoPageState extends State<TodoPage> {
     );
   }
 
-  //Não vale a pena transformar esse componente em um not-smart widget
-  FloatingActionButton _buildAddButton() {
-    return FloatingActionButton(
+  Widget _buildAddButton() {
+    return AddFloatingActionButton(
       onPressed: () async {
         if (_todoItems.isEmpty || _todoItems.last.id != TodoItem.newItemId) {
           setState(() {
@@ -219,7 +217,6 @@ class _TodoPageState extends State<TodoPage> {
         }
         _lastFocusNode?.requestFocus();
       },
-      child: const Icon(Icons.add),
     );
   }
 }

--- a/lib/todo_page.dart
+++ b/lib/todo_page.dart
@@ -141,7 +141,7 @@ class _TodoPageState extends State<TodoPage> {
     final focusNode = lastItem ? FocusNode() : null;
     if (lastItem) _lastFocusNode = focusNode;
     return TodoItemWidget(
-      key: ValueKey(todoItem),
+      key: Key("todo-item-${todoItem.id}"),
       todoItem: todoItem,
       focusNode: focusNode,
       onDismissed: (direction) => _onDismissed(index, context, todoItem),

--- a/lib/widgets/actions/add_floating_action_button.dart
+++ b/lib/widgets/actions/add_floating_action_button.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class AddFloatingActionButton extends StatelessWidget {
+  const AddFloatingActionButton({
+    super.key,
+    required this.onPressed,
+  });
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      onPressed: onPressed,
+      child: const Icon(Icons.add),
+    );
+  }
+}

--- a/lib/widgets/actions/copy_action.dart
+++ b/lib/widgets/actions/copy_action.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class CopyAction extends StatelessWidget {
+  const CopyAction({
+    super.key,
+    required this.onPressed,
+  });
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: onPressed,
+      icon: const Icon(Icons.copy),
+    );
+  }
+}

--- a/lib/widgets/actions/delete_all_action.dart
+++ b/lib/widgets/actions/delete_all_action.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class DeleteAllAction extends StatelessWidget {
+  const DeleteAllAction({
+    super.key,
+    required this.onPressed,
+  });
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: onPressed,
+      icon: const Icon(Icons.delete_forever),
+    );
+  }
+}

--- a/lib/widgets/actions/sort_action.dart
+++ b/lib/widgets/actions/sort_action.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class SortAction extends StatelessWidget {
+  const SortAction({
+    super.key,
+    required this.onPressed,
+  });
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: onPressed,
+      icon: const Icon(Icons.sort),
+    );
+  }
+}

--- a/lib/widgets/dialog/delete_all_confirmation_dialog.dart
+++ b/lib/widgets/dialog/delete_all_confirmation_dialog.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class DeleteAllConfirmationDialog extends StatelessWidget {
+  const DeleteAllConfirmationDialog({
+    super.key,
+    required this.onConfirmPressed,
+  });
+
+  final VoidCallback onConfirmPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text("Do you want to clear all your list?"),
+      content: const Text(
+        "Pressing 'yes', all your list will be deleted and can't be restored",
+      ),
+      actions: [
+        TextButton(
+          onPressed: Navigator.of(context).pop,
+          child: const Text("No"),
+        ),
+        _buildDeleteAllConfirmButton(context),
+      ],
+    );
+  }
+
+  TextButton _buildDeleteAllConfirmButton(BuildContext context) {
+    return TextButton(
+      onPressed: onConfirmPressed,
+      child: Text(
+        "Yes",
+        style: Theme.of(context).textTheme.button?.copyWith(
+              color: Colors.red,
+            ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/todo_item/todo_item_widget.dart
+++ b/lib/widgets/todo_item/todo_item_widget.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:todo_app/todo_item.dart';
+
+class TodoItemWidget extends StatelessWidget {
+  const TodoItemWidget({
+    super.key,
+    required this.todoItem,
+    this.focusNode,
+    required this.onDismissed,
+    required this.onCheckboxChanged,
+    required this.onTextFieldChanged,
+  });
+
+  final TodoItem todoItem;
+  final FocusNode? focusNode;
+  final DismissDirectionCallback onDismissed;
+  final ValueChanged<bool?> onCheckboxChanged;
+  final ValueChanged<String> onTextFieldChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: ValueKey(todoItem.id),
+      onDismissed: onDismissed,
+      background: Container(color: Colors.red),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Row(
+          children: [
+            _buildItemCheckbox(),
+            Expanded(
+              child: _buildItemTextField(),
+            ),
+            Icon(
+              Icons.menu,
+              key: ValueKey("drag-icon-${todoItem.id}"),
+            ),
+            const SizedBox(width: 8),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Checkbox _buildItemCheckbox() {
+    return Checkbox(
+      value: todoItem.done,
+      onChanged: onCheckboxChanged,
+    );
+  }
+
+  TextField _buildItemTextField() {
+    return TextField(
+      focusNode: focusNode,
+      controller: TextEditingController(
+        text: todoItem.description,
+      ),
+      minLines: 1,
+      maxLines: 5,
+      onChanged: onTextFieldChanged,
+    );
+  }
+}

--- a/lib/widgets/todo_item/todo_item_widget.dart
+++ b/lib/widgets/todo_item/todo_item_widget.dart
@@ -20,7 +20,7 @@ class TodoItemWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Dismissible(
-      key: ValueKey(todoItem.id),
+      key: Key("dismissible-${todoItem.id}"),
       onDismissed: onDismissed,
       background: Container(color: Colors.red),
       child: Padding(
@@ -31,10 +31,7 @@ class TodoItemWidget extends StatelessWidget {
             Expanded(
               child: _buildItemTextField(),
             ),
-            Icon(
-              Icons.menu,
-              key: ValueKey("drag-icon-${todoItem.id}"),
-            ),
+            const Icon(Icons.menu),
             const SizedBox(width: 8),
           ],
         ),

--- a/test/todo_page_test.dart
+++ b/test/todo_page_test.dart
@@ -13,8 +13,10 @@ import 'package:todo_app/widgets/actions/copy_action.dart';
 import 'package:todo_app/widgets/actions/delete_all_action.dart';
 import 'package:todo_app/widgets/actions/sort_action.dart';
 import 'package:todo_app/widgets/dialog/delete_all_confirmation_dialog.dart';
+import 'package:todo_app/widgets/todo_item/todo_item_widget.dart';
 
 import 'widgets/dialog/delete_all_confirmation_dialog_tester.dart';
+import 'widgets/todo_item/todo_item_widget_tester.dart';
 
 void main() {
   late LocalDataSource localDataSource;
@@ -273,15 +275,18 @@ void main() {
 
             await pumpTodoPage(tester);
 
-            final dragWidgetFinder0 = find.byKey(const ValueKey("drag-icon-0"));
+            final dragWidgetFinder0 = find.descendant(
+              of: find.byKey(const Key("todo-item-0")),
+              matching: TodoItemWidgetTester.getDragIconFinder(),
+            );
             final dragGesture = await tester.startGesture(
               tester.getCenter(dragWidgetFinder0),
             );
             await tester.pump(kLongPressTimeout + kPressTimeout);
 
-            final dragWidgetFinder1 = find.byKey(const ValueKey("drag-icon-1"));
+            final todoItemWidget1Finder = find.byKey(const Key("todo-item-1"));
             await dragGesture
-                .moveTo(tester.getBottomLeft(dragWidgetFinder1) * 2);
+                .moveTo(tester.getBottomLeft(todoItemWidget1Finder) * 2);
             await dragGesture.up();
 
             await tester.pumpAndSettle();
@@ -305,14 +310,18 @@ void main() {
 
             await pumpTodoPage(tester);
 
-            final dragWidgetFinder1 = find.byKey(const ValueKey("drag-icon-1"));
+            final dragWidgetFinder1 = find.descendant(
+              of: find.byKey(const Key("todo-item-1")),
+              matching: TodoItemWidgetTester.getDragIconFinder(),
+            );
             final dragGesture = await tester.startGesture(
               tester.getCenter(dragWidgetFinder1),
             );
             await tester.pump(kLongPressTimeout + kPressTimeout);
 
-            final dragWidgetFinder0 = find.byKey(const ValueKey("drag-icon-0"));
-            await dragGesture.moveTo(tester.getTopLeft(dragWidgetFinder0) * -2);
+            final todoItemWidget0Finder = find.byKey(const Key("todo-item-0"));
+            await dragGesture
+                .moveTo(tester.getTopLeft(todoItemWidget0Finder) * -2);
             await dragGesture.up();
 
             await tester.pumpAndSettle();
@@ -337,7 +346,10 @@ void main() {
 
             await pumpTodoPage(tester);
 
-            final dragWidgetFinder0 = find.byKey(const ValueKey("drag-icon-0"));
+            final dragWidgetFinder0 = find.descendant(
+              of: find.byKey(const Key("todo-item-0")),
+              matching: TodoItemWidgetTester.getDragIconFinder(),
+            );
             await tester.drag(
               dragWidgetFinder0,
               const Offset(-500, 0),
@@ -362,7 +374,10 @@ void main() {
 
             await pumpTodoPage(tester);
 
-            final dragWidgetFinder0 = find.byKey(const ValueKey("drag-icon-0"));
+            final dragWidgetFinder0 = find.descendant(
+              of: find.byKey(const Key("todo-item-0")),
+              matching: TodoItemWidgetTester.getDragIconFinder(),
+            );
             await tester.drag(
               dragWidgetFinder0,
               const Offset(-500, 0),
@@ -376,41 +391,7 @@ void main() {
         );
       });
 
-      group("Checkbox", () {
-        testWidgets(
-          "given a todo list item with done = false, "
-          "when pumped, "
-          "then expects to find a checkbox not checked",
-          (tester) async {
-            final todoItem0 = _MockTodoItem();
-            when(() => todoItem0.done).thenReturn(false);
-            todoItems.add(todoItem0);
-
-            await pumpTodoPage(tester);
-
-            final finder = find.byType(Checkbox);
-            final checkbox = tester.widget(finder) as Checkbox;
-            expect(checkbox.value, isFalse);
-          },
-        );
-
-        testWidgets(
-          "given a todo list item with done = true, "
-          "when pumped, "
-          "then expects to find a checked checkbox",
-          (tester) async {
-            final todoItem0 = _MockTodoItem();
-            when(() => todoItem0.done).thenReturn(true);
-            todoItems.add(todoItem0);
-
-            await pumpTodoPage(tester);
-
-            final finder = find.byType(Checkbox);
-            final checkbox = tester.widget(finder) as Checkbox;
-            expect(checkbox.value, isTrue);
-          },
-        );
-
+      group("Update done", () {
         testWidgets(
           "given a todo list item with done = false, "
           "when checkbox of the item is tapped, "
@@ -425,7 +406,7 @@ void main() {
 
             await pumpTodoPage(tester);
 
-            await tester.tap(find.byType(Checkbox));
+            await TodoItemWidgetTester.tapToChangeDone(tester);
 
             verify(
               () => localDataSource.saveTodoItems(
@@ -455,7 +436,7 @@ void main() {
 
             await pumpTodoPage(tester);
 
-            await tester.tap(find.byType(Checkbox));
+            await TodoItemWidgetTester.tapToChangeDone(tester);
 
             verify(
               () => localDataSource.saveTodoItems(
@@ -472,26 +453,7 @@ void main() {
         );
       });
 
-      group("TextField", () {
-        testWidgets(
-          "given a todo list item with a description, "
-          "when pumped, "
-          "then expects to find a text field with that description",
-          (tester) async {
-            const description = "mock description";
-
-            final todoItem0 = _MockTodoItem();
-            when(() => todoItem0.description).thenReturn(description);
-            todoItems.add(todoItem0);
-
-            await pumpTodoPage(tester);
-
-            final finder = find.byType(TextField);
-            final textField = tester.widget(finder) as TextField;
-            expect(textField.controller?.text, description);
-          },
-        );
-
+      group("Update description", () {
         testWidgets(
           "given a todo list item, "
           "when text field is editted, "
@@ -509,7 +471,10 @@ void main() {
 
             const newDescription = "new mock description";
             await tester.enterText(
-              find.byType(TextField),
+              find.descendant(
+                of: find.byKey(const Key("todo-item-0")),
+                matching: TodoItemWidgetTester.getDescriptionField(),
+              ),
               newDescription,
             );
 
@@ -533,7 +498,7 @@ void main() {
       testWidgets(
         "given a empty todo list, "
         "when floating action button is tapped, "
-        "then expects to find a checkbox unchecked",
+        "then expects to find TodoItemWidget with a new TodoItem",
         (tester) async {
           todoItems.clear();
 
@@ -542,29 +507,11 @@ void main() {
           await tester.tap(find.byType(AddFloatingActionButton));
           await tester.pumpAndSettle();
 
-          final finder = find.byType(Checkbox);
-          final checkbox = tester.widget(finder) as Checkbox;
-          expect(checkbox.value, isFalse);
-
-          await tester.pumpAndSettle();
-        },
-      );
-
-      testWidgets(
-        "given a empty todo list, "
-        "when floating action button is tapped, "
-        "then expects to find a empty text field",
-        (tester) async {
-          todoItems.clear();
-
-          await pumpTodoPage(tester);
-
-          await tester.tap(find.byType(AddFloatingActionButton));
-          await tester.pumpAndSettle();
-
-          final finder = find.byType(TextField);
-          final textField = tester.widget(finder) as TextField;
-          expect(textField.controller?.text, isEmpty);
+          final finder = find.byType(TodoItemWidget);
+          final todoItemWidget = tester.widget(finder) as TodoItemWidget;
+          expect(todoItemWidget.todoItem.id, TodoItem.newItemId);
+          expect(todoItemWidget.todoItem.description, isNull);
+          expect(todoItemWidget.todoItem.done, isFalse);
 
           await tester.pumpAndSettle();
         },
@@ -643,7 +590,7 @@ void main() {
 
           const description = "mock description";
           await tester.enterText(
-            find.byType(TextField),
+            TodoItemWidgetTester.getDescriptionField(),
             description,
           );
 

--- a/test/todo_page_test.dart
+++ b/test/todo_page_test.dart
@@ -8,6 +8,13 @@ import 'package:mocktail/mocktail.dart';
 import 'package:todo_app/local_data_source.dart';
 import 'package:todo_app/todo_item.dart';
 import 'package:todo_app/todo_page.dart';
+import 'package:todo_app/widgets/actions/add_floating_action_button.dart';
+import 'package:todo_app/widgets/actions/copy_action.dart';
+import 'package:todo_app/widgets/actions/delete_all_action.dart';
+import 'package:todo_app/widgets/actions/sort_action.dart';
+import 'package:todo_app/widgets/dialog/delete_all_confirmation_dialog.dart';
+
+import 'widgets/dialog/delete_all_confirmation_dialog_tester.dart';
 
 void main() {
   late LocalDataSource localDataSource;
@@ -34,7 +41,7 @@ void main() {
       when(localDataSource.getTodoItems).thenReturn(todoItems);
     });
 
-    group("Sort button", () {
+    group("SortAction", () {
       testWidgets(
         "given an empty todo list, "
         "when pumped,"
@@ -44,9 +51,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          final finder = find.byWidgetPredicate(
-            (widget) => widget is Icon && widget.icon == Icons.sort,
-          );
+          final finder = find.byType(SortAction);
           expect(finder, findsNothing);
         },
       );
@@ -62,9 +67,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          final finder = find.byWidgetPredicate(
-            (widget) => widget is Icon && widget.icon == Icons.sort,
-          );
+          final finder = find.byType(SortAction);
           expect(finder, findsNothing);
         },
       );
@@ -84,9 +87,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          final finder = find.byWidgetPredicate(
-            (widget) => widget is Icon && widget.icon == Icons.sort,
-          );
+          final finder = find.byType(SortAction);
           expect(finder, findsOneWidget);
         },
       );
@@ -106,9 +107,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          final finder = find.byWidgetPredicate(
-            (widget) => widget is Icon && widget.icon == Icons.sort,
-          );
+          final finder = find.byType(SortAction);
           await tester.tap(finder);
 
           expect(todoItems, [doneTodoItem, notDoneTodoItem]);
@@ -130,9 +129,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          final finder = find.byWidgetPredicate(
-            (widget) => widget is Icon && widget.icon == Icons.sort,
-          );
+          final finder = find.byType(SortAction);
           await tester.tap(finder);
 
           expect(todoItems, [doneTodoItem, notDoneTodoItem]);
@@ -140,7 +137,7 @@ void main() {
       );
     });
 
-    group("Copy button", () {
+    group("CopyAction", () {
       testWidgets(
         "given an empty todo list item, "
         "when pumped, "
@@ -150,9 +147,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          final finder = find.byWidgetPredicate(
-            (widget) => widget is Icon && widget.icon == Icons.copy,
-          );
+          final finder = find.byType(CopyAction);
           expect(finder, findsNothing);
         },
       );
@@ -185,9 +180,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          final finder = find.byWidgetPredicate(
-            (widget) => widget is Icon && widget.icon == Icons.copy,
-          );
+          final finder = find.byType(CopyAction);
           await tester.tap(finder);
 
           expect(result, "[ ] not done\n[X] done");
@@ -195,7 +188,7 @@ void main() {
       );
     });
 
-    group("Delete all button", () {
+    group("DeleteAllAction", () {
       testWidgets(
         "given an empty todo list item, "
         "when pumped, "
@@ -205,9 +198,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          final finder = find.byWidgetPredicate(
-            (widget) => widget is Icon && widget.icon == Icons.delete_forever,
-          );
+          final finder = find.byType(DeleteAllAction);
           expect(finder, findsNothing);
         },
       );
@@ -215,48 +206,19 @@ void main() {
       testWidgets(
         "given a todo list item, "
         "when delete all button is clicked, "
-        "then expects to find the confirmation dialog",
+        "then expects to find DeleteAllConfirmationDialog",
         (tester) async {
           todoItems.add(_MockTodoItem());
           todoItems.add(_MockTodoItem());
 
           await pumpTodoPage(tester);
 
-          final finder = find.byWidgetPredicate(
-            (widget) => widget is Icon && widget.icon == Icons.delete_forever,
-          );
+          final finder = find.byType(DeleteAllAction);
           await tester.tap(finder);
           await tester.pumpAndSettle();
 
-          final titleFinder = find.text("Do you want to clear all your list?");
-          expect(titleFinder, findsOneWidget);
-
-          final contentFinder = find.text(
-            "Pressing 'yes', all your list will be deleted and can't be restored",
-          );
-          expect(contentFinder, findsOneWidget);
-        },
-      );
-
-      testWidgets(
-        "given a todo list item, "
-        "when delete all button is clicked and then 'no' button is clicked, "
-        "then expects to find the same items on the list",
-        (tester) async {
-          todoItems.add(_MockTodoItem());
-          todoItems.add(_MockTodoItem());
-
-          await pumpTodoPage(tester);
-
-          final finder = find.byWidgetPredicate(
-            (widget) => widget is Icon && widget.icon == Icons.delete_forever,
-          );
-          await tester.tap(finder);
-          await tester.pumpAndSettle();
-
-          await tester.tap(find.text("No"));
-
-          expect(todoItems.length, 2);
+          final dialogFinder = find.byType(DeleteAllConfirmationDialog);
+          expect(dialogFinder, findsOneWidget);
         },
       );
 
@@ -275,13 +237,11 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          final finder = find.byWidgetPredicate(
-            (widget) => widget is Icon && widget.icon == Icons.delete_forever,
-          );
+          final finder = find.byType(DeleteAllAction);
           await tester.tap(finder);
           await tester.pumpAndSettle();
 
-          await tester.tap(find.text("Yes"));
+          await DeleteAllConfirmationDialogTester.callOnPressed(tester);
 
           expect(todoItems.isEmpty, isTrue);
         },
@@ -569,7 +529,7 @@ void main() {
       });
     });
 
-    group("FloatingActionButton", () {
+    group("AddFloatingActionButton", () {
       testWidgets(
         "given a empty todo list, "
         "when floating action button is tapped, "
@@ -579,7 +539,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          await tester.tap(find.byType(FloatingActionButton));
+          await tester.tap(find.byType(AddFloatingActionButton));
           await tester.pumpAndSettle();
 
           final finder = find.byType(Checkbox);
@@ -599,7 +559,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          await tester.tap(find.byType(FloatingActionButton));
+          await tester.tap(find.byType(AddFloatingActionButton));
           await tester.pumpAndSettle();
 
           final finder = find.byType(TextField);
@@ -619,7 +579,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          await tester.tap(find.byType(FloatingActionButton));
+          await tester.tap(find.byType(AddFloatingActionButton));
           await tester.pumpAndSettle();
 
           expect(todoItems.isNotEmpty, isTrue);
@@ -637,7 +597,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          await tester.tap(find.byType(FloatingActionButton));
+          await tester.tap(find.byType(AddFloatingActionButton));
           await tester.pumpAndSettle();
 
           registerFallbackValue(_FakeTodoItem());
@@ -656,8 +616,8 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          await tester.tap(find.byType(FloatingActionButton));
-          await tester.tap(find.byType(FloatingActionButton));
+          await tester.tap(find.byType(AddFloatingActionButton));
+          await tester.tap(find.byType(AddFloatingActionButton));
           await tester.pumpAndSettle();
 
           expect(todoItems.length, 1);
@@ -678,7 +638,7 @@ void main() {
 
           await pumpTodoPage(tester);
 
-          await tester.tap(find.byType(FloatingActionButton));
+          await tester.tap(find.byType(AddFloatingActionButton));
           await tester.pumpAndSettle();
 
           const description = "mock description";

--- a/test/widgets/dialog/delete_all_confirmation_dialog_test.dart
+++ b/test/widgets/dialog/delete_all_confirmation_dialog_test.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:todo_app/widgets/dialog/delete_all_confirmation_dialog.dart';
+
+void main() {
+  Future<void> pumpDialog(
+    WidgetTester tester, {
+    VoidCallback? onConfirmPressed,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+        ),
+        home: DeleteAllConfirmationDialog(
+          onConfirmPressed: onConfirmPressed ?? () {},
+        ),
+      ),
+    );
+  }
+
+  group("DeleteAllConfirmationDialog", () {
+    testWidgets(
+      "when pumped, "
+      "then expects to find title",
+      (tester) async {
+        await pumpDialog(tester);
+
+        final titleFinder = find.text("Do you want to clear all your list?");
+        expect(titleFinder, findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      "when pumped, "
+      "then expects to find description",
+      (tester) async {
+        await pumpDialog(tester);
+
+        final contentFinder = find.text(
+          "Pressing 'yes', all your list will be deleted and can't be restored",
+        );
+        expect(contentFinder, findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      "when 'no' button is clicked, "
+      "then not expects to call onConfirmPressed callback",
+      (tester) async {
+        final completer = Completer();
+        final onConfirmPressed = completer.complete;
+
+        await pumpDialog(
+          tester,
+          onConfirmPressed: onConfirmPressed,
+        );
+
+        await tester.tap(find.text('No'));
+
+        expect(completer.isCompleted, isFalse);
+      },
+    );
+
+    testWidgets(
+      "when 'Yes' button is clicked, "
+      "then expects to call onConfirmPressed callback",
+      (tester) async {
+        final completer = Completer();
+        final onConfirmPressed = completer.complete;
+
+        await pumpDialog(
+          tester,
+          onConfirmPressed: onConfirmPressed,
+        );
+
+        await tester.tap(find.text('Yes'));
+
+        expect(completer.isCompleted, isTrue);
+      },
+    );
+  });
+}

--- a/test/widgets/dialog/delete_all_confirmation_dialog_tester.dart
+++ b/test/widgets/dialog/delete_all_confirmation_dialog_tester.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+class DeleteAllConfirmationDialogTester {
+  static Future<void> callOnPressed(WidgetTester tester) {
+    return tester.tap(find.text("Yes"));
+  }
+}

--- a/test/widgets/todo_item/todo_item_widget_test.dart
+++ b/test/widgets/todo_item/todo_item_widget_test.dart
@@ -1,0 +1,195 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:todo_app/todo_item.dart';
+import 'package:todo_app/widgets/todo_item/todo_item_widget.dart';
+
+void main() {
+  late TodoItem todoItem;
+
+  Future<void> pumpTodoItemWidget(
+    WidgetTester tester, {
+    FocusNode? focusNode,
+    DismissDirectionCallback? onDismissed,
+    ValueChanged<bool?>? onCheckboxChanged,
+    ValueChanged<String>? onTextFieldChanged,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+        ),
+        home: Material(
+          child: TodoItemWidget(
+            todoItem: todoItem,
+            onCheckboxChanged: onCheckboxChanged ?? (_) {},
+            onDismissed: onDismissed ?? (_) {},
+            onTextFieldChanged: onTextFieldChanged ?? (_) {},
+            focusNode: focusNode,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group("TodoItemWidget", () {
+    setUp(() {
+      todoItem = _MockTodoItem();
+      when(() => todoItem.id).thenReturn(0);
+      when(() => todoItem.done).thenReturn(false);
+      when(() => todoItem.description).thenReturn("");
+    });
+
+    group("Checkbox", () {
+      testWidgets(
+        "given a todo item with done = false, "
+        "when pumped, "
+        "then expects to find a checkbox not checked",
+        (tester) async {
+          when(() => todoItem.done).thenReturn(false);
+
+          await pumpTodoItemWidget(tester);
+
+          final finder = find.byType(Checkbox);
+          final checkbox = tester.widget(finder) as Checkbox;
+          expect(checkbox.value, isFalse);
+        },
+      );
+
+      testWidgets(
+        "given a todo item with done = true, "
+        "when pumped, "
+        "then expects to find a checkbox checked",
+        (tester) async {
+          when(() => todoItem.done).thenReturn(true);
+
+          await pumpTodoItemWidget(tester);
+
+          final finder = find.byType(Checkbox);
+          final checkbox = tester.widget(finder) as Checkbox;
+          expect(checkbox.value, isTrue);
+        },
+      );
+
+      testWidgets(
+        "given a todo item with done = false, "
+        "when checkbox is tapped, "
+        "then expects to call onCheckboxChanged callback with true",
+        (tester) async {
+          when(() => todoItem.done).thenReturn(false);
+
+          bool? result;
+          onCheckboxChanged(changed) {
+            result = changed;
+          }
+
+          await pumpTodoItemWidget(
+            tester,
+            onCheckboxChanged: onCheckboxChanged,
+          );
+          await tester.tap(find.byType(Checkbox));
+
+          expect(result, isTrue);
+        },
+      );
+
+      testWidgets(
+        "given a todo item with done = true, "
+        "when checkbox is tapped, "
+        "then expects to call onCheckboxChanged callback with false",
+        (tester) async {
+          when(() => todoItem.done).thenReturn(true);
+
+          bool? result;
+          onCheckboxChanged(changed) {
+            result = changed;
+          }
+
+          await pumpTodoItemWidget(
+            tester,
+            onCheckboxChanged: onCheckboxChanged,
+          );
+          await tester.tap(find.byType(Checkbox));
+
+          expect(result, isFalse);
+        },
+      );
+    });
+
+    group("TextField", () {
+      testWidgets(
+        "given a todo list item with a description, "
+        "when pumped, "
+        "then expects to find a text field with that description",
+        (tester) async {
+          const description = "mock description";
+          when(() => todoItem.description).thenReturn(description);
+
+          await pumpTodoItemWidget(tester);
+
+          final finder = find.byType(TextField);
+          final textField = tester.widget(finder) as TextField;
+          expect(textField.controller?.text, description);
+        },
+      );
+
+      testWidgets(
+        "given a todo item with done = false, "
+        "when checkbox is tapped, "
+        "then expects to call onCheckboxChanged callback with true",
+        (tester) async {
+          String? result;
+          onTextFieldChanged(description) {
+            result = description;
+          }
+
+          await pumpTodoItemWidget(
+            tester,
+            onTextFieldChanged: onTextFieldChanged,
+          );
+
+          const newDescription = "new mocked description";
+          await tester.enterText(
+            find.byType(TextField),
+            newDescription,
+          );
+
+          expect(result, newDescription);
+        },
+      );
+    });
+
+    group("Dismissible", () {
+      testWidgets(
+        "when drag icon widget and swiped to left, "
+        "then expects to call onDismissed",
+        (tester) async {
+          final completer = Completer();
+          onDismissed(direction) {
+            completer.complete();
+          }
+
+          await pumpTodoItemWidget(
+            tester,
+            onDismissed: onDismissed,
+          );
+
+          final dragIconFinder = find.byWidgetPredicate(
+            (widget) => widget is Icon && widget.icon == Icons.menu,
+          );
+          await tester.drag(
+            dragIconFinder,
+            const Offset(-1000, 0),
+          );
+          await tester.pumpAndSettle();
+
+          expect(completer.isCompleted, isTrue);
+        },
+      );
+    });
+  });
+}
+
+class _MockTodoItem extends Mock implements TodoItem {}

--- a/test/widgets/todo_item/todo_item_widget_tester.dart
+++ b/test/widgets/todo_item/todo_item_widget_tester.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class TodoItemWidgetTester {
+  static Finder getDragIconFinder() {
+    return find.byWidgetPredicate(
+      (widget) => widget is Icon && widget.icon == Icons.menu,
+    );
+  }
+
+  static Future<void> tapToChangeDone(WidgetTester tester) {
+    return tester.tap(find.byType(Checkbox));
+  }
+
+  static Finder getDescriptionField() {
+    return find.byType(TextField);
+  }
+}


### PR DESCRIPTION
### os botões de ação da `AppBar` e o _floating action button_ de adicionar item

Não valeu a pena transformar os botões de ação da `AppBar` e o _floating action button_ de adicionar item em widgets not-smart: ganho quase ínfimo no número de linhas e melhorou a organização quase que insignificantemente. Teríamos vantagem em deixar mais explícito para quê aquele componente serve sem precisar olhar muito o código, mas o nome do método criado na etapa de _helper method_ já faz essa função.

Nos testes, a mudança foi um pouco maior, mas não significante o suficiente.

### dialog e item da lista

Transformar o dialog e o item da lista em widgets not-smart impactaram bastante o número de linhas e a legibilidade do código.

Isso causou um efeito colateral interessante nos testes: como o efeito dos botões do dialog e das interações com o componente do item da lista são definidos pela `TodoPage`, os testes da `TodoPage` precisaram ter noção de como o widget está sendo implementado e não só saber "o que o widget faz", o que seria ideal. Por tanto, criei uma classe com sufixo `Tester` para os widgets dentro da pasta de teste de cada widget para abstrair detalhes da implementação para os testes.

Além disso, como consequência mais natural, alguns dos testes que faziam parte da suíte de testes do `TodoPage`, passaram para outro arquivo, para fazerem parte da suíte de testes de cada widget correspondente.

### Testes de _callback_: `Tester.callOnPressed` vs `widget.onPressed()`

Abordagem tester:
```dart
class DeleteAllConfirmationDialogTester {
  static Future<void> callOnPressed(WidgetTester tester) {
    return tester.tap(find.text("Yes"));
  }
}

\\...
await DeleteAllConfirmationDialogTester.callOnPressed(tester);
```

Ou

Abordagem chamando callback:
```dart
final widget = tester.widget(
    find.byType(DeleteAllConfirmationDialog),
) as DeleteAllConfirmationDialog;
widget.onPressed();
```
?

Nesse cenário, as duas abordagens parecem okay para mim. As coisas começam a ficar mais interessantes quando o _callback_ recebe um paâmetro que é calculado dentro do "_widget_ dependência":

Na primeira abordagem, seria necessário um método para cada cenário diferente do parâmetro que seria passado. 

Na segunda abordagem, esse valor pode ser passado diretamente, porém, os parâmetros precisarão ser mockados com cuidado.

Uma situação que passei e inviabilizou o uso da segunda abordagem: se o _callback_ deve retornar algum valor para desencadear alguma cadeia de eventos dentro do "_widget dependência_", chamando `widget.onPressed()` diretamente do teste impede que o retorno seja tratado da maneira correta. Por exemplo, se o _callback_ for um `WidgetBuilder` para ser colocado na árvore de _widget_ do "_widget dependência_", o _widget_ retornado não será inserido na árvore e as eventuais consequências disso não poderão ser testadas