### PR TITLE
Bloc with not-smart widgets

### DIFF
--- a/lib/bloc/todo_bloc.dart
+++ b/lib/bloc/todo_bloc.dart
@@ -1,0 +1,210 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:todo_app/bloc/todo_event.dart';
+import 'package:todo_app/bloc/todo_state.dart';
+import 'package:todo_app/local_data_source.dart';
+import 'package:todo_app/todo_item.dart';
+
+class TodoBloc extends Bloc<TodoEvent, TodoState> {
+  TodoBloc(
+    this._localDataSource,
+  ) : super(_getInitialState(_localDataSource)) {
+    on<TodoSortEvent>(_onSort);
+    on<TodoDeleteAllEvent>(_onDeleteAll);
+    on<TodoReorderEvent>(_onReorder);
+    on<TodoDescriptionUpdateEvent>(_onDescriptionUpdate);
+    on<TodoDoneUpdateEvent>(_onDoneUpdate);
+    on<TodoDismissedEvent>(_onDismiss);
+    on<TodoUndoDismissedEvent>(_onUndoDismiss);
+    on<TodoAddItemEvent>(_onAddItem);
+    on<TodoCopyEvent>(_onCopy);
+  }
+
+  final LocalDataSource _localDataSource;
+
+  static TodoState _getInitialState(LocalDataSource localDataSource) {
+    final todoItems = localDataSource.getTodoItems();
+    return TodoState(
+      todoItems: todoItems,
+      textCopied: null,
+      lastAction: TodoAction.none,
+      showCopyButton: _getShowCopyButton(todoItems),
+      showDeleteAllButton: _getShowDeleteAllButton(todoItems),
+      showSortButton: _getShowSortButton(todoItems),
+    );
+  }
+
+  FutureOr<void> _onSort(event, Emitter<TodoState> emit) async {
+    final sortedList = state.todoItems.toList()
+      ..sort((todoItem0, todoItem1) {
+        if (todoItem0.done && !todoItem1.done) {
+          return -1;
+        }
+        if (!todoItem0.done && todoItem1.done) {
+          return 1;
+        }
+        return 0;
+      });
+    await _localDataSource.saveTodoItems(sortedList);
+    emit(
+      state.copyWith(
+        todoItems: sortedList,
+      ),
+    );
+  }
+
+  FutureOr<void> _onDeleteAll(
+    TodoDeleteAllEvent event,
+    Emitter<TodoState> emit,
+  ) {
+    final clearedList = state.todoItems.toList()..clear();
+    _localDataSource.saveTodoItems(clearedList);
+    emit(
+      state.copyWith(
+        todoItems: clearedList,
+        showCopyButton: _getShowCopyButton(clearedList),
+        showDeleteAllButton: _getShowDeleteAllButton(clearedList),
+        showSortButton: _getShowSortButton(clearedList),
+      ),
+    );
+  }
+
+  FutureOr<void> _onReorder(
+    TodoReorderEvent event,
+    Emitter<TodoState> emit,
+  ) {
+    final reorderList = state.todoItems.toList();
+
+    final todoItem = reorderList[event.oldIndex];
+    reorderList.insert(event.newIndex, todoItem);
+    if (event.oldIndex > event.newIndex) {
+      reorderList.removeAt(event.oldIndex + 1);
+    } else {
+      reorderList.removeAt(event.oldIndex);
+    }
+    _localDataSource.saveTodoItems(state.todoItems);
+
+    emit(
+      state.copyWith(
+        todoItems: reorderList,
+      ),
+    );
+  }
+
+  FutureOr<void> _onDescriptionUpdate(
+    TodoDescriptionUpdateEvent event,
+    Emitter<TodoState> emit,
+  ) {
+    final newItem = event.todoItem.id == TodoItem.newItemId;
+
+    final updatedList = state.todoItems.toList();
+    updatedList[event.index] = event.todoItem.copyWith(
+      id: newItem ? updatedList.length : null,
+      description: event.newDescription,
+    );
+    _localDataSource.saveTodoItems(updatedList);
+
+    emit(state.copyWith(
+      todoItems: updatedList,
+    ));
+  }
+
+  FutureOr<void> _onDoneUpdate(
+    TodoDoneUpdateEvent event,
+    Emitter<TodoState> emit,
+  ) {
+    final updatedList = state.todoItems.toList();
+    updatedList[event.index] = event.todoItem.copyWith(
+      done: event.newDoneValue,
+    );
+    if (event.todoItem.id != TodoItem.newItemId) {
+      _localDataSource.saveTodoItems(updatedList);
+    }
+    emit(state.copyWith(
+      todoItems: updatedList,
+      showSortButton: _getShowSortButton(updatedList),
+    ));
+  }
+
+  FutureOr<void> _onDismiss(
+    TodoDismissedEvent event,
+    Emitter<TodoState> emit,
+  ) {
+    final updatedList = state.todoItems.toList();
+    updatedList.removeAt(event.index);
+
+    _localDataSource.saveTodoItems(updatedList);
+
+    emit(state.copyWith(
+      todoItems: updatedList,
+      showCopyButton: _getShowCopyButton(updatedList),
+      showDeleteAllButton: _getShowDeleteAllButton(updatedList),
+      showSortButton: _getShowSortButton(updatedList),
+    ));
+  }
+
+  FutureOr<void> _onUndoDismiss(
+    TodoUndoDismissedEvent event,
+    Emitter<TodoState> emit,
+  ) {
+    final updatedList = state.todoItems.toList();
+    updatedList.insert(event.index, event.todoItem);
+
+    _localDataSource.saveTodoItems(updatedList);
+
+    emit(state.copyWith(
+      todoItems: updatedList,
+      showCopyButton: _getShowCopyButton(updatedList),
+      showDeleteAllButton: _getShowDeleteAllButton(updatedList),
+      showSortButton: _getShowSortButton(updatedList),
+    ));
+  }
+
+  FutureOr<void> _onAddItem(
+    TodoAddItemEvent event,
+    Emitter<TodoState> emit,
+  ) {
+    final updatedList = state.todoItems.toList();
+    if (updatedList.isEmpty || updatedList.last.id != TodoItem.newItemId) {
+      updatedList.add(TodoItem.newItem());
+      emit(state.copyWith(
+        todoItems: updatedList,
+        lastAction: TodoAction.newItem,
+        showCopyButton: _getShowCopyButton(updatedList),
+        showDeleteAllButton: _getShowDeleteAllButton(updatedList),
+        showSortButton: _getShowSortButton(updatedList),
+      ));
+    }
+  }
+
+  FutureOr<void> _onCopy(
+    TodoCopyEvent event,
+    Emitter<TodoState> emit,
+  ) {
+    final todoItemsAsString = state.todoItems.map(
+      (e) {
+        if (e.done) {
+          return "[X] ${e.description}";
+        }
+        return "[ ] ${e.description}";
+      },
+    ).join("\n");
+    emit(state.copyWith(
+      textCopied: todoItemsAsString,
+      lastAction: TodoAction.copied,
+    ));
+  }
+
+  static bool _getShowCopyButton(List<TodoItem> todoItems) {
+    return todoItems.isNotEmpty;
+  }
+
+  static bool _getShowDeleteAllButton(List<TodoItem> todoItems) {
+    return todoItems.isNotEmpty;
+  }
+
+  static bool _getShowSortButton(List<TodoItem> todoItems) {
+    return todoItems.any((element) => element.done);
+  }
+}

--- a/lib/bloc/todo_bloc.dart
+++ b/lib/bloc/todo_bloc.dart
@@ -35,7 +35,10 @@ class TodoBloc extends Bloc<TodoEvent, TodoState> {
     );
   }
 
-  FutureOr<void> _onSort(event, Emitter<TodoState> emit) async {
+  FutureOr<void> _onSort(
+    TodoSortEvent event,
+    Emitter<TodoState> emit,
+  ) async {
     final sortedList = state.todoItems.toList()
       ..sort((todoItem0, todoItem1) {
         if (todoItem0.done && !todoItem1.done) {
@@ -77,13 +80,15 @@ class TodoBloc extends Bloc<TodoEvent, TodoState> {
     final reorderList = state.todoItems.toList();
 
     final todoItem = reorderList[event.oldIndex];
-    reorderList.insert(event.newIndex, todoItem);
+
     if (event.oldIndex > event.newIndex) {
+      reorderList.insert(event.newIndex, todoItem);
       reorderList.removeAt(event.oldIndex + 1);
     } else {
+      reorderList.insert(event.newIndex + 1, todoItem);
       reorderList.removeAt(event.oldIndex);
     }
-    _localDataSource.saveTodoItems(state.todoItems);
+    _localDataSource.saveTodoItems(reorderList);
 
     emit(
       state.copyWith(
@@ -100,7 +105,7 @@ class TodoBloc extends Bloc<TodoEvent, TodoState> {
 
     final updatedList = state.todoItems.toList();
     updatedList[event.index] = event.todoItem.copyWith(
-      id: newItem ? updatedList.length : null,
+      id: newItem ? updatedList.length - 1 : null,
       description: event.newDescription,
     );
     _localDataSource.saveTodoItems(updatedList);

--- a/lib/bloc/todo_event.dart
+++ b/lib/bloc/todo_event.dart
@@ -1,0 +1,110 @@
+import 'package:equatable/equatable.dart';
+import 'package:todo_app/todo_item.dart';
+
+abstract class TodoEvent extends Equatable {}
+
+class TodoSortEvent extends TodoEvent {
+  @override
+  List<Object?> get props => [];
+}
+
+class TodoDeleteAllEvent extends TodoEvent {
+  @override
+  List<Object?> get props => [];
+}
+
+class TodoReorderEvent extends TodoEvent {
+  final int oldIndex;
+  final int newIndex;
+
+  TodoReorderEvent({
+    required this.oldIndex,
+    required this.newIndex,
+  });
+
+  @override
+  List<Object?> get props => [
+        oldIndex,
+        newIndex,
+      ];
+}
+
+class TodoDescriptionUpdateEvent extends TodoEvent {
+  final TodoItem todoItem;
+  final int index;
+  final String newDescription;
+
+  TodoDescriptionUpdateEvent({
+    required this.todoItem,
+    required this.index,
+    required this.newDescription,
+  });
+
+  @override
+  List<Object?> get props => [
+        todoItem,
+        index,
+        newDescription,
+      ];
+}
+
+class TodoDoneUpdateEvent extends TodoEvent {
+  final TodoItem todoItem;
+  final int index;
+  final bool newDoneValue;
+
+  TodoDoneUpdateEvent({
+    required this.todoItem,
+    required this.index,
+    required this.newDoneValue,
+  });
+
+  @override
+  List<Object?> get props => [
+        todoItem,
+        index,
+        newDoneValue,
+      ];
+}
+
+class TodoDismissedEvent extends TodoEvent {
+  final TodoItem todoItem;
+  final int index;
+
+  TodoDismissedEvent({
+    required this.todoItem,
+    required this.index,
+  });
+
+  @override
+  List<Object?> get props => [
+        todoItem,
+        index,
+      ];
+}
+
+class TodoUndoDismissedEvent extends TodoEvent {
+  final TodoItem todoItem;
+  final int index;
+
+  TodoUndoDismissedEvent({
+    required this.todoItem,
+    required this.index,
+  });
+
+  @override
+  List<Object?> get props => [
+        todoItem,
+        index,
+      ];
+}
+
+class TodoAddItemEvent extends TodoEvent {
+  @override
+  List<Object?> get props => [];
+}
+
+class TodoCopyEvent extends TodoEvent {
+  @override
+  List<Object?> get props => [];
+}

--- a/lib/bloc/todo_state.dart
+++ b/lib/bloc/todo_state.dart
@@ -1,0 +1,54 @@
+import 'package:equatable/equatable.dart';
+import 'package:todo_app/todo_item.dart';
+
+enum TodoAction {
+  none,
+  newItem,
+  copied,
+}
+
+class TodoState extends Equatable {
+  final List<TodoItem> todoItems;
+  final TodoAction lastAction;
+  final String? textCopied;
+  final bool showSortButton;
+  final bool showDeleteAllButton;
+  final bool showCopyButton;
+
+  const TodoState({
+    required this.todoItems,
+    required this.lastAction,
+    required this.textCopied,
+    required this.showSortButton,
+    required this.showDeleteAllButton,
+    required this.showCopyButton,
+  });
+
+  @override
+  List<Object?> get props => [
+        todoItems,
+        lastAction,
+        textCopied,
+        showSortButton,
+        showDeleteAllButton,
+        showCopyButton,
+      ];
+
+  TodoState copyWith({
+    List<TodoItem>? todoItems,
+    TodoAction? lastAction,
+    String? textCopied,
+    bool? showSortButton,
+    bool? showDeleteAllButton,
+    bool? showCopyButton,
+  }) {
+    return TodoState(
+      todoItems: todoItems ?? this.todoItems,
+      lastAction: lastAction ?? this.lastAction,
+      textCopied: textCopied ?? this.textCopied,
+      showSortButton: showSortButton ?? this.showSortButton,
+      showDeleteAllButton: showDeleteAllButton ?? this.showDeleteAllButton,
+      showCopyButton: showCopyButton ?? this.showCopyButton,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:todo_app/bloc/todo_bloc.dart';
 import 'package:todo_app/local_data_source.dart';
 import 'package:todo_app/todo_page.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
   final sharedPreferences = await SharedPreferences.getInstance();
   final localDataSource = LocalDataSource(sharedPreferences);
 
@@ -27,8 +31,9 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: TodoPage(
-        localDataSource: localDataSource,
+      home: BlocProvider(
+        create: (context) => TodoBloc(localDataSource),
+        child: const TodoPage(),
       ),
     );
   }

--- a/lib/todo_page.dart
+++ b/lib/todo_page.dart
@@ -68,17 +68,13 @@ class _TodoPageState extends State<TodoPage> {
 
   Widget _buildSortButton() {
     return SortAction(
-      onPressed: () {
-        _bloc.add(TodoSortEvent());
-      },
+      onPressed: () => _bloc.add(TodoSortEvent()),
     );
   }
 
   Widget _buildCopyMethod() {
     return CopyAction(
-      onPressed: () async {
-        _bloc.add(TodoCopyEvent());
-      },
+      onPressed: () => _bloc.add(TodoCopyEvent()),
     );
   }
 

--- a/lib/todo_page.dart
+++ b/lib/todo_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:todo_app/local_data_source.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:todo_app/bloc/todo_bloc.dart';
+import 'package:todo_app/bloc/todo_event.dart';
+import 'package:todo_app/bloc/todo_state.dart';
 import 'package:todo_app/todo_item.dart';
 import 'package:todo_app/widgets/actions/add_floating_action_button.dart';
 import 'package:todo_app/widgets/actions/copy_action.dart';
@@ -12,69 +15,61 @@ import 'package:todo_app/widgets/todo_item/todo_item_widget.dart';
 class TodoPage extends StatefulWidget {
   const TodoPage({
     super.key,
-    required this.localDataSource,
   });
-
-  final LocalDataSource localDataSource;
 
   @override
   State<TodoPage> createState() => _TodoPageState();
 }
 
 class _TodoPageState extends State<TodoPage> {
-  LocalDataSource get _localDataSource => widget.localDataSource;
-  List<TodoItem> _todoItems = List.empty(growable: true);
+  TodoBloc get _bloc => BlocProvider.of<TodoBloc>(context);
+
+  List<TodoItem> get _todoItems => _bloc.state.todoItems;
   FocusNode? _lastFocusNode;
 
   @override
-  void initState() {
-    super.initState();
-    _loadItems();
-  }
-
-  void _loadItems() async {
-    setState(() {
-      _todoItems = _localDataSource.getTodoItems();
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text("TODO"),
-        actions: [
-          if (_todoItems.any((element) => element.done)) _buildSortButton(),
-          if (_todoItems.isNotEmpty) _buildCopyMethod(),
-          if (_todoItems.isNotEmpty) _buildDeleteAllButton(),
-        ],
-      ),
-      body: ReorderableListView.builder(
-        padding: const EdgeInsets.only(
-          bottom: 56,
-        ),
-        itemCount: _todoItems.length,
-        onReorder: _onReorder,
-        itemBuilder: _itemBuilder,
-      ),
-      floatingActionButton: _buildAddButton(),
+    return BlocConsumer<TodoBloc, TodoState>(
+      listener: _todoBlocListener,
+      builder: (context, state) {
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text("TODO"),
+            actions: [
+              if (state.showSortButton) _buildSortButton(),
+              if (state.showCopyButton) _buildCopyMethod(),
+              if (state.showDeleteAllButton) _buildDeleteAllButton(),
+            ],
+          ),
+          body: ReorderableListView.builder(
+            padding: const EdgeInsets.only(
+              bottom: 56,
+            ),
+            itemCount: _todoItems.length,
+            onReorder: _onReorder,
+            itemBuilder: _itemBuilder,
+          ),
+          floatingActionButton: _buildAddButton(),
+        );
+      },
     );
+  }
+
+  void _todoBlocListener(context, state) async {
+    switch (state.lastAction) {
+      case TodoAction.newItem:
+        return _focusOnLastNodeWithDelay();
+      case TodoAction.copied:
+        await Clipboard.setData(ClipboardData(text: state.textCopied));
+        break;
+      default:
+    }
   }
 
   Widget _buildSortButton() {
     return SortAction(
       onPressed: () {
-        setState(() {
-          _todoItems.sort((todoItem0, todoItem1) {
-            if (todoItem0.done && !todoItem1.done) {
-              return -1;
-            }
-            if (!todoItem0.done && todoItem1.done) {
-              return 1;
-            }
-            return 0;
-          });
-        });
+        _bloc.add(TodoSortEvent());
       },
     );
   }
@@ -82,17 +77,7 @@ class _TodoPageState extends State<TodoPage> {
   Widget _buildCopyMethod() {
     return CopyAction(
       onPressed: () async {
-        final todoItemsAsString = _todoItems.map(
-          (e) {
-            if (e.done) {
-              return "[X] ${e.description}";
-            }
-            return "[ ] ${e.description}";
-          },
-        ).join("\n");
-        await Clipboard.setData(
-          ClipboardData(text: todoItemsAsString),
-        );
+        _bloc.add(TodoCopyEvent());
       },
     );
   }
@@ -113,26 +98,17 @@ class _TodoPageState extends State<TodoPage> {
   Widget _buildConfirmationDialog() {
     return DeleteAllConfirmationDialog(
       onConfirmPressed: () {
-        setState(() {
-          _todoItems.clear();
-          _localDataSource.saveTodoItems(_todoItems);
-          Navigator.of(context).pop();
-        });
+        _bloc.add(TodoDeleteAllEvent());
+        Navigator.of(context).pop();
       },
     );
   }
 
-  void _onReorder(oldIndex, newIndex) {
-    setState(() {
-      final todoItem = _todoItems[oldIndex];
-      _todoItems.insert(newIndex, todoItem);
-      if (oldIndex > newIndex) {
-        _todoItems.removeAt(oldIndex + 1);
-      } else {
-        _todoItems.removeAt(oldIndex);
-      }
-      _localDataSource.saveTodoItems(_todoItems);
-    });
+  void _onReorder(int oldIndex, int newIndex) {
+    _bloc.add(TodoReorderEvent(
+      oldIndex: oldIndex,
+      newIndex: newIndex,
+    ));
   }
 
   Widget _itemBuilder(BuildContext context, int index) {
@@ -152,24 +128,19 @@ class _TodoPageState extends State<TodoPage> {
   }
 
   void _onTextFieldChanged(TodoItem todoItem, int index, String value) {
-    final newItem = todoItem.id == TodoItem.newItemId;
-
-    _todoItems[index] = todoItem.copyWith(
-      id: newItem ? _todoItems.length : null,
-      description: value,
-    );
-    _localDataSource.saveTodoItems(_todoItems);
+    _bloc.add(TodoDescriptionUpdateEvent(
+      todoItem: todoItem,
+      index: index,
+      newDescription: value,
+    ));
   }
 
   void _onCheckboxChanged(int index, TodoItem todoItem, bool? value) {
-    setState(() {
-      _todoItems[index] = todoItem.copyWith(
-        done: value,
-      );
-      if (todoItem.id != TodoItem.newItemId) {
-        _localDataSource.saveTodoItems(_todoItems);
-      }
-    });
+    _bloc.add(TodoDoneUpdateEvent(
+      todoItem: todoItem,
+      index: index,
+      newDoneValue: value ?? false,
+    ));
   }
 
   void _onDismissed(
@@ -177,10 +148,10 @@ class _TodoPageState extends State<TodoPage> {
     BuildContext context,
     TodoItem todoItem,
   ) {
-    setState(() {
-      _todoItems.removeAt(index);
-      _localDataSource.saveTodoItems(_todoItems);
-    });
+    _bloc.add(TodoDismissedEvent(
+      todoItem: todoItem,
+      index: index,
+    ));
 
     _showUndoSnackbar(context, index, todoItem);
   }
@@ -196,10 +167,10 @@ class _TodoPageState extends State<TodoPage> {
         action: SnackBarAction(
           label: "Undo",
           onPressed: () {
-            setState(() {
-              _todoItems.insert(index, todoItem);
-              _localDataSource.saveTodoItems(_todoItems);
-            });
+            _bloc.add(TodoUndoDismissedEvent(
+              todoItem: todoItem,
+              index: index,
+            ));
           },
         ),
       ),
@@ -209,14 +180,13 @@ class _TodoPageState extends State<TodoPage> {
   Widget _buildAddButton() {
     return AddFloatingActionButton(
       onPressed: () async {
-        if (_todoItems.isEmpty || _todoItems.last.id != TodoItem.newItemId) {
-          setState(() {
-            _todoItems.add(TodoItem.newItem());
-          });
-          await Future.delayed(const Duration(milliseconds: 500));
-        }
-        _lastFocusNode?.requestFocus();
+        _bloc.add(TodoAddItemEvent());
       },
     );
+  }
+
+  void _focusOnLastNodeWithDelay() async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    _lastFocusNode?.requestFocus();
   }
 }

--- a/lib/todo_page.dart
+++ b/lib/todo_page.dart
@@ -179,9 +179,7 @@ class _TodoPageState extends State<TodoPage> {
 
   Widget _buildAddButton() {
     return AddFloatingActionButton(
-      onPressed: () async {
-        _bloc.add(TodoAddItemEvent());
-      },
+      onPressed: () => _bloc.add(TodoAddItemEvent()),
     );
   }
 

--- a/lib/widgets/todo_item/todo_item_widget.dart
+++ b/lib/widgets/todo_item/todo_item_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:todo_app/todo_item.dart';
 
-class TodoItemWidget extends StatelessWidget {
+class TodoItemWidget extends StatefulWidget {
   const TodoItemWidget({
     super.key,
     required this.todoItem,
@@ -18,10 +18,23 @@ class TodoItemWidget extends StatelessWidget {
   final ValueChanged<String> onTextFieldChanged;
 
   @override
+  State<TodoItemWidget> createState() => _TodoItemWidgetState();
+}
+
+class _TodoItemWidgetState extends State<TodoItemWidget> {
+  final textController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    textController.text = widget.todoItem.description ?? "";
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Dismissible(
-      key: Key("dismissible-${todoItem.id}"),
-      onDismissed: onDismissed,
+      key: Key("dismissible-${widget.todoItem.id}"),
+      onDismissed: widget.onDismissed,
       background: Container(color: Colors.red),
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 8),
@@ -41,20 +54,18 @@ class TodoItemWidget extends StatelessWidget {
 
   Checkbox _buildItemCheckbox() {
     return Checkbox(
-      value: todoItem.done,
-      onChanged: onCheckboxChanged,
+      value: widget.todoItem.done,
+      onChanged: widget.onCheckboxChanged,
     );
   }
 
   TextField _buildItemTextField() {
     return TextField(
-      focusNode: focusNode,
-      controller: TextEditingController(
-        text: todoItem.description,
-      ),
+      focusNode: widget.focusNode,
+      controller: textController,
       minLines: 1,
       maxLines: 5,
-      onChanged: onTextFieldChanged,
+      onChanged: widget.onTextFieldChanged,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,6 +36,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.1.0"
+  bloc_test:
+    dependency: "direct main"
+    description:
+      name: bloc_test
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "9.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -92,6 +99,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
+  diff_match_patch:
+    dependency: transitive
+    description:
+      name: diff_match_patch
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.1"
   equatable:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -114,7 +114,7 @@ packages:
     source: hosted
     version: "2.0.5"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,6 +29,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.9.0"
+  bloc:
+    dependency: transitive
+    description:
+      name: bloc
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -118,6 +125,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_bloc:
+    dependency: "direct main"
+    description:
+      name: flutter_bloc
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.1.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -226,6 +240,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
@@ -296,6 +317,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.2.4"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.3"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dev_dependencies:
     sdk: flutter
   mocktail: ^0.3.0
   flutter_lints: ^2.0.0
+  fake_async: ^1.3.1
 
 flutter:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   shared_preferences: ^2.0.15
   equatable: ^2.0.5
+  flutter_bloc: ^8.1.1
   
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   shared_preferences: ^2.0.15
   equatable: ^2.0.5
   flutter_bloc: ^8.1.1
+  bloc_test: ^9.1.0
   
 
 dev_dependencies:

--- a/test/bloc/todo_bloc_test.dart
+++ b/test/bloc/todo_bloc_test.dart
@@ -1,0 +1,795 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:todo_app/bloc/todo_bloc.dart';
+import 'package:todo_app/bloc/todo_event.dart';
+import 'package:todo_app/bloc/todo_state.dart';
+import 'package:todo_app/local_data_source.dart';
+import 'package:todo_app/todo_item.dart';
+
+void main() {
+  late TodoBloc bloc;
+
+  late LocalDataSource localDataSource;
+  late List<TodoItem> todoItems;
+
+  group("TodoBloc", () {
+    setUp(() {
+      todoItems = List.empty(growable: true);
+
+      localDataSource = _MockLocalDataSource();
+      when(localDataSource.getTodoItems).thenReturn(todoItems);
+      when(() => localDataSource.saveTodoItems(todoItems))
+          .thenAnswer((_) async => true);
+
+      bloc = TodoBloc(localDataSource);
+    });
+
+    group("TodoSortEvent", () {
+      late TodoItem doneTodoItem;
+      late TodoItem undoneTodoItem;
+
+      setUp(() {
+        doneTodoItem = _MockTodoItem();
+        when(() => doneTodoItem.done).thenReturn(true);
+
+        undoneTodoItem = _MockTodoItem();
+        when(() => undoneTodoItem.done).thenReturn(false);
+
+        when(
+          () => localDataSource.saveTodoItems([
+            doneTodoItem,
+            undoneTodoItem,
+          ]),
+        ).thenAnswer((_) async => true);
+      });
+
+      blocTest(
+        "given a todo list with one undone item at first and a done item at second, "
+        "when TodoSortEvent is added, "
+        "then expects to emit a TodoState done item at first on list",
+        build: () => bloc,
+        setUp: () {
+          todoItems.add(undoneTodoItem);
+          todoItems.add(doneTodoItem);
+        },
+        act: (bloc) => bloc.add(TodoSortEvent()),
+        expect: () => [
+          TodoState(
+            todoItems: [
+              doneTodoItem,
+              undoneTodoItem,
+            ],
+            lastAction: TodoAction.none,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: false,
+            showCopyButton: false,
+          ),
+        ],
+      );
+
+      blocTest(
+        "given a todo list with one done item at first and a undone item at second, "
+        "when TodoSortEvent is added, "
+        "then expects to emit a TodoState done item at first on list",
+        build: () => bloc,
+        setUp: () {
+          todoItems.add(doneTodoItem);
+          todoItems.add(undoneTodoItem);
+        },
+        act: (bloc) => bloc.add(TodoSortEvent()),
+        expect: () => [
+          TodoState(
+            todoItems: [
+              doneTodoItem,
+              undoneTodoItem,
+            ],
+            lastAction: TodoAction.none,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: false,
+            showCopyButton: false,
+          ),
+        ],
+      );
+
+      blocTest(
+        "given a todo list with one undone item at first and a done item at second, "
+        "when TodoSortEvent is added, "
+        "then expects to call localDataSource.saveTodoList()",
+        build: () => bloc,
+        setUp: () {
+          todoItems.add(undoneTodoItem);
+          todoItems.add(doneTodoItem);
+        },
+        act: (bloc) => bloc.add(TodoSortEvent()),
+        verify: (_) {
+          verify(
+            () => localDataSource.saveTodoItems([doneTodoItem, undoneTodoItem]),
+          ).called(1);
+        },
+      );
+    });
+
+    group("TodoDeleteAllEvent", () {
+      setUp(() {
+        todoItems.add(_MockTodoItem());
+
+        when(
+          () => localDataSource.saveTodoItems([]),
+        ).thenAnswer((invocation) async => true);
+      });
+
+      blocTest(
+        "when TodoDeleteAllEvent is added, "
+        "then expects to emit TodoState with an empty todo list",
+        build: () => bloc,
+        act: (bloc) => bloc.add(TodoDeleteAllEvent()),
+        expect: () => [
+          const TodoState(
+            todoItems: [],
+            lastAction: TodoAction.none,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: false,
+            showCopyButton: false,
+          ),
+        ],
+      );
+
+      blocTest(
+        "when TodoDeleteAllEvent is added, "
+        "then expects to call localDataSource.saveTodoList() passing a empty list",
+        build: () => bloc,
+        act: (bloc) => bloc.add(TodoDeleteAllEvent()),
+        verify: (_) {
+          verify(
+            () => localDataSource.saveTodoItems([]),
+          ).called(1);
+        },
+      );
+    });
+
+    group("TodoReorderEvent", () {
+      late TodoItem todoItem0;
+      late TodoItem todoItem1;
+      late TodoItem todoItem2;
+
+      setUp(() {
+        todoItem0 = _MockTodoItem();
+        when(() => todoItem0.id).thenReturn(0);
+        todoItems.add(todoItem0);
+
+        todoItem1 = _MockTodoItem();
+        when(() => todoItem1.id).thenReturn(1);
+        todoItems.add(todoItem1);
+
+        todoItem2 = _MockTodoItem();
+        when(() => todoItem2.id).thenReturn(2);
+        todoItems.add(todoItem2);
+      });
+
+      blocTest(
+        "given a todo list, "
+        "when TodoReorderEvent is added with oldIndex smaller than newIndex, "
+        "then expects to emit a TodoState with reordered items",
+        build: () => bloc,
+        setUp: () {
+          when(
+            () => localDataSource.saveTodoItems([
+              todoItem1,
+              todoItem2,
+              todoItem0,
+            ]),
+          ).thenAnswer((invocation) async => true);
+        },
+        act: (bloc) => bloc.add(TodoReorderEvent(
+          oldIndex: 0,
+          newIndex: 2,
+        )),
+        expect: () => [
+          TodoState(
+            todoItems: [
+              todoItem1,
+              todoItem2,
+              todoItem0,
+            ],
+            lastAction: TodoAction.none,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: false,
+            showCopyButton: false,
+          ),
+        ],
+      );
+
+      blocTest(
+        "given a todo list, "
+        "when TodoReorderEvent is added with newIndex smaller than oldIndex, "
+        "then expects to emit a TodoState with reordered items",
+        build: () => bloc,
+        setUp: () {
+          when(
+            () => localDataSource.saveTodoItems([
+              todoItem2,
+              todoItem0,
+              todoItem1,
+            ]),
+          ).thenAnswer((invocation) async => true);
+        },
+        act: (bloc) => bloc.add(TodoReorderEvent(
+          oldIndex: 2,
+          newIndex: 0,
+        )),
+        expect: () => [
+          TodoState(
+            todoItems: [
+              todoItem2,
+              todoItem0,
+              todoItem1,
+            ],
+            lastAction: TodoAction.none,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: false,
+            showCopyButton: false,
+          ),
+        ],
+      );
+    });
+
+    group("TodoDescriptionUpdateEvent", () {
+      late TodoItem todoItem;
+
+      setUp(() {
+        todoItem = const TodoItem(
+          id: 0,
+          done: false,
+          description: "description",
+        );
+        todoItems.add(todoItem);
+      });
+
+      blocTest(
+        "given a todo item, "
+        "when TodoDescriptionUpdateEvent is added, "
+        "then expects to emit TodoState with item with updated description",
+        build: () => bloc,
+        setUp: () {
+          when(
+            () => localDataSource.saveTodoItems(
+              const [
+                TodoItem(
+                  id: 0,
+                  description: "new description",
+                  done: false,
+                )
+              ],
+            ),
+          ).thenAnswer((invocation) async => true);
+        },
+        act: (bloc) => bloc.add(
+          TodoDescriptionUpdateEvent(
+            todoItem: todoItem,
+            index: 0,
+            newDescription: "new description",
+          ),
+        ),
+        expect: () => const [
+          TodoState(
+            todoItems: [
+              TodoItem(
+                id: 0,
+                description: "new description",
+                done: false,
+              ),
+            ],
+            lastAction: TodoAction.none,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: false,
+            showCopyButton: false,
+          ),
+        ],
+      );
+
+      blocTest(
+        "given a todo item with new item id, "
+        "when TodoDescriptionUpdateEvent is added, "
+        "then expects to emit TodoState with item with updated description"
+        " and a new id",
+        build: () => bloc,
+        setUp: () {
+          todoItem = const TodoItem(
+            id: TodoItem.newItemId,
+            description: "new item description",
+            done: true,
+          );
+          todoItems.add(todoItem);
+
+          when(
+            () => localDataSource.saveTodoItems(
+              const [
+                TodoItem(
+                  id: 0,
+                  description: "description",
+                  done: false,
+                ),
+                TodoItem(
+                  id: 1,
+                  description: "new description",
+                  done: true,
+                ),
+              ],
+            ),
+          ).thenAnswer((invocation) async => true);
+        },
+        act: (bloc) => bloc.add(
+          TodoDescriptionUpdateEvent(
+            todoItem: todoItems[1],
+            index: 1,
+            newDescription: "new description",
+          ),
+        ),
+        expect: () => const [
+          TodoState(
+            todoItems: [
+              TodoItem(
+                id: 0,
+                description: "description",
+                done: false,
+              ),
+              TodoItem(
+                id: 1,
+                description: "new description",
+                done: true,
+              ),
+            ],
+            lastAction: TodoAction.none,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: false,
+            showCopyButton: false,
+          ),
+        ],
+      );
+
+      blocTest(
+        "given a todo item, "
+        "when TodoDescriptionUpdateEvent is added, "
+        "then expects to verify localDataSource.saveTodoItems with item with updated description",
+        build: () => bloc,
+        setUp: () {
+          when(
+            () => localDataSource.saveTodoItems(
+              const [
+                TodoItem(
+                  id: 0,
+                  description: "new description",
+                  done: false,
+                )
+              ],
+            ),
+          ).thenAnswer((invocation) async => true);
+        },
+        act: (bloc) => bloc.add(
+          TodoDescriptionUpdateEvent(
+            todoItem: todoItem,
+            index: 0,
+            newDescription: "new description",
+          ),
+        ),
+        verify: (bloc) {
+          verify(
+            () => localDataSource.saveTodoItems(
+              const [
+                TodoItem(
+                  id: 0,
+                  description: "new description",
+                  done: false,
+                )
+              ],
+            ),
+          ).called(1);
+        },
+      );
+    });
+
+    group("TodoDoneUpdateEvent", () {
+      late TodoItem todoItem;
+
+      setUp(() {
+        todoItem = const TodoItem(
+          id: 0,
+          description: "description",
+          done: false,
+        );
+        todoItems.add(todoItem);
+      });
+
+      blocTest(
+        "given a todo item with done = false, "
+        "when TodoDoneUpdateEvent is added, "
+        "then expects to emit TodoState with item with done = true",
+        build: () => bloc,
+        setUp: () {
+          when(
+            () => localDataSource.saveTodoItems(
+              [
+                todoItem.copyWith(
+                  done: true,
+                )
+              ],
+            ),
+          ).thenAnswer((invocation) async => true);
+        },
+        act: (bloc) => bloc.add(
+          TodoDoneUpdateEvent(
+            todoItem: todoItem,
+            index: 0,
+            newDoneValue: true,
+          ),
+        ),
+        expect: () => [
+          TodoState(
+            todoItems: [
+              todoItem.copyWith(
+                done: true,
+              ),
+            ],
+            lastAction: TodoAction.none,
+            textCopied: null,
+            showSortButton: true,
+            showDeleteAllButton: false,
+            showCopyButton: false,
+          ),
+        ],
+      );
+
+      blocTest(
+        "given a todo item with done = true, "
+        "when TodoDoneUpdateEvent is added, "
+        "then expects to emit TodoState with item with done = false",
+        build: () => bloc,
+        setUp: () {
+          todoItem = const TodoItem(
+            id: TodoItem.newItemId,
+            description: "description",
+            done: true,
+          );
+          todoItems.add(todoItem);
+
+          when(
+            () => localDataSource.saveTodoItems(
+              [
+                todoItem.copyWith(
+                  done: false,
+                )
+              ],
+            ),
+          ).thenAnswer((invocation) async => true);
+        },
+        act: (bloc) => bloc.add(
+          TodoDoneUpdateEvent(
+            todoItem: todoItem,
+            index: 1,
+            newDoneValue: false,
+          ),
+        ),
+        expect: () => const [
+          TodoState(
+            todoItems: [
+              TodoItem(
+                id: 0,
+                description: "description",
+                done: false,
+              ),
+              TodoItem(
+                id: TodoItem.newItemId,
+                description: "description",
+                done: false,
+              ),
+            ],
+            lastAction: TodoAction.none,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: false,
+            showCopyButton: false,
+          ),
+        ],
+      );
+
+      blocTest(
+        "given a todo item, "
+        "when TodoDoneUpdateEvent is added, "
+        "then expects to verify localDataSource.saveTodoItems with item with updated done",
+        build: () => bloc,
+        setUp: () {
+          when(
+            () => localDataSource.saveTodoItems(
+              const [
+                TodoItem(
+                  id: 0,
+                  description: "description",
+                  done: true,
+                )
+              ],
+            ),
+          ).thenAnswer((invocation) async => true);
+        },
+        act: (bloc) => bloc.add(
+          TodoDoneUpdateEvent(
+            todoItem: todoItem,
+            index: 0,
+            newDoneValue: true,
+          ),
+        ),
+        verify: (bloc) {
+          verify(
+            () => localDataSource.saveTodoItems(
+              const [
+                TodoItem(
+                  id: 0,
+                  description: "description",
+                  done: true,
+                )
+              ],
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest(
+        "given a todo item with new item id, "
+        "when TodoDoneUpdateEvent is added, "
+        "then not expects to verify localDataSource.saveTodoItems with item with updated done",
+        build: () => bloc,
+        setUp: () {
+          todoItem = const TodoItem(
+            id: TodoItem.newItemId,
+            description: "description",
+            done: true,
+          );
+          todoItems.add(todoItem);
+        },
+        act: (bloc) => bloc.add(
+          TodoDoneUpdateEvent(
+            todoItem: todoItems[1],
+            index: 1,
+            newDoneValue: false,
+          ),
+        ),
+        verify: (bloc) {
+          registerFallbackValue(_MockTodoItem());
+          verifyNever(
+            () => localDataSource.saveTodoItems(captureAny()),
+          );
+        },
+      );
+    });
+
+    group("TodoDismissedEvent", () {
+      late TodoItem todoItem;
+
+      setUp(() {
+        todoItem = _MockTodoItem();
+        when(() => todoItem.done).thenReturn(false);
+        todoItems.add(todoItem);
+      });
+
+      blocTest(
+        "when TodoDismissedEvent is added, "
+        "then expect to emit TodoState without item removed",
+        setUp: () {
+          when(
+            () => localDataSource.saveTodoItems([]),
+          ).thenAnswer((invocation) async => true);
+        },
+        build: () => bloc,
+        act: (bloc) => bloc.add(
+          TodoDismissedEvent(
+            todoItem: todoItem,
+            index: 0,
+          ),
+        ),
+        expect: () => const [
+          TodoState(
+            todoItems: [],
+            lastAction: TodoAction.none,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: false,
+            showCopyButton: false,
+          ),
+        ],
+      );
+
+      blocTest(
+        "when TodoDismissedEvent is added, "
+        "then expect to verify localDataSource.saveTodoItems with "
+        "the list without deleted item",
+        setUp: () {
+          final todoItem0 = _MockTodoItem();
+          when(() => todoItem0.done).thenReturn(false);
+          todoItems.add(todoItem0);
+
+          when(
+            () => localDataSource.saveTodoItems([todoItem]),
+          ).thenAnswer((invocation) async => true);
+        },
+        build: () => bloc,
+        act: (bloc) => bloc.add(
+          TodoDismissedEvent(
+            todoItem: todoItems[1],
+            index: 1,
+          ),
+        ),
+        verify: (bloc) {
+          verify(
+            () => localDataSource.saveTodoItems([todoItem]),
+          ).called(1);
+        },
+      );
+    });
+
+    group("TodoUndoDismissedEvent", () {
+      late TodoItem todoItem;
+
+      setUp(() {
+        todoItem = _MockTodoItem();
+        when(() => todoItem.done).thenReturn(false);
+      });
+
+      blocTest(
+        "when TodoUndoDismissedEvent is added, "
+        "then expects to emit TodoState with the item re-inserted",
+        build: () => bloc,
+        setUp: () {
+          when(
+            () => localDataSource.saveTodoItems([todoItem]),
+          ).thenAnswer((invocation) async => true);
+        },
+        act: (bloc) => bloc.add(
+          TodoUndoDismissedEvent(
+            todoItem: todoItem,
+            index: 0,
+          ),
+        ),
+        expect: () => [
+          TodoState(
+            todoItems: [todoItem],
+            lastAction: TodoAction.none,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: true,
+            showCopyButton: true,
+          ),
+        ],
+      );
+    });
+
+    group("TodoAddItemEvent", () {
+      late TodoItem todoItem;
+
+      setUp(() {
+        todoItem = _MockTodoItem();
+        when(() => todoItem.id).thenReturn(0);
+        when(() => todoItem.done).thenReturn(false);
+      });
+
+      blocTest(
+        "given a empty todo list, "
+        "when TodoAddItemEvent is added, "
+        "then expects to emit TodoState with the new item",
+        build: () => bloc,
+        setUp: () {
+          todoItems.clear();
+        },
+        act: (bloc) => bloc.add(TodoAddItemEvent()),
+        expect: () => const [
+          TodoState(
+            todoItems: [
+              TodoItem(
+                id: TodoItem.newItemId,
+                description: null,
+                done: false,
+              ),
+            ],
+            lastAction: TodoAction.newItem,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: true,
+            showCopyButton: true,
+          ),
+        ],
+      );
+
+      blocTest(
+        "given a not empty todo list, "
+        "when TodoAddItemEvent is added, "
+        "then expects to emit TodoState with the new item",
+        build: () => bloc,
+        setUp: () {
+          todoItems.add(todoItem);
+        },
+        act: (bloc) => bloc.add(TodoAddItemEvent()),
+        expect: () => [
+          TodoState(
+            todoItems: [
+              todoItem,
+              const TodoItem(
+                id: TodoItem.newItemId,
+                description: null,
+                done: false,
+              ),
+            ],
+            lastAction: TodoAction.newItem,
+            textCopied: null,
+            showSortButton: false,
+            showDeleteAllButton: true,
+            showCopyButton: true,
+          ),
+        ],
+      );
+
+      blocTest(
+        "given a empty todo list, "
+        "when TodoAddItemEvent is added, "
+        "then not expects to verify localDataSource.saveTodoItems",
+        build: () => bloc,
+        setUp: () {
+          todoItems.clear();
+        },
+        act: (bloc) => bloc.add(TodoAddItemEvent()),
+        verify: (bloc) {
+          registerFallbackValue(_FakeTodoItem());
+          verifyNever(
+            () => localDataSource.saveTodoItems(captureAny()),
+          );
+        },
+      );
+    });
+
+    group("TodoCopyEvent", () {
+      setUp(() {
+        const todoItem0 = TodoItem(
+          id: 0,
+          description: "description 0",
+          done: false,
+        );
+        todoItems.add(todoItem0);
+
+        const todoItem1 = TodoItem(
+          id: 1,
+          description: "description 1",
+          done: true,
+        );
+        todoItems.add(todoItem1);
+      });
+
+      blocTest(
+        "when TodoCopyEvent is added, "
+        "then expects to emit TodoState with text to copy",
+        build: () => bloc,
+        act: (bloc) => bloc.add(TodoCopyEvent()),
+        expect: () => [
+          TodoState(
+            todoItems: todoItems,
+            lastAction: TodoAction.copied,
+            textCopied: "[ ] description 0\n[X] description 1",
+            showSortButton: false,
+            showDeleteAllButton: false,
+            showCopyButton: false,
+          ),
+        ],
+      );
+    });
+  });
+}
+
+class _MockLocalDataSource extends Mock implements LocalDataSource {}
+
+class _MockTodoItem extends Mock implements TodoItem {}
+
+class _FakeTodoItem extends Fake implements TodoItem {}

--- a/test/todo_page_test.dart
+++ b/test/todo_page_test.dart
@@ -1,10 +1,16 @@
 import 'dart:math';
 
+import 'package:bloc_test/bloc_test.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:todo_app/bloc/todo_bloc.dart';
+import 'package:todo_app/bloc/todo_event.dart';
+import 'package:todo_app/bloc/todo_state.dart';
 import 'package:todo_app/local_data_source.dart';
 import 'package:todo_app/todo_item.dart';
 import 'package:todo_app/todo_page.dart';
@@ -21,6 +27,8 @@ import 'widgets/todo_item/todo_item_widget_tester.dart';
 void main() {
   late LocalDataSource localDataSource;
   late List<TodoItem> todoItems;
+  late TodoBloc todoBloc;
+  late TodoState initialTodoState;
 
   Future<void> pumpTodoPage(WidgetTester tester) {
     return tester.pumpWidget(
@@ -28,8 +36,9 @@ void main() {
         theme: ThemeData(
           primarySwatch: Colors.blue,
         ),
-        home: TodoPage(
-          _localDataSource: localDataSource,
+        home: BlocProvider.value(
+          value: todoBloc,
+          child: const TodoPage(),
         ),
       ),
     );
@@ -41,51 +50,38 @@ void main() {
 
       localDataSource = _MockLocalDataSource();
       when(localDataSource.getTodoItems).thenReturn(todoItems);
+
+      todoBloc = _MockTodoBloc();
+      initialTodoState = _MockTodoState();
+      when(() => initialTodoState.todoItems).thenReturn(todoItems);
+      whenListen(
+        todoBloc,
+        const Stream<TodoState>.empty(),
+        initialState: initialTodoState,
+      );
     });
 
     group("SortAction", () {
       testWidgets(
-        "given an empty todo list, "
-        "when pumped,"
-        " then not expects to find sort button",
-        (tester) async {
-          todoItems.clear();
-
-          await pumpTodoPage(tester);
-
-          final finder = find.byType(SortAction);
-          expect(finder, findsNothing);
-        },
-      );
-
-      testWidgets(
-        "given a todo list with no done items, "
-        "when pumped,"
-        " then not expects to find sort button",
-        (tester) async {
-          final mockTodoItem = _MockTodoItem();
-          when(() => mockTodoItem.done).thenReturn(false);
-          todoItems.add(mockTodoItem);
-
-          await pumpTodoPage(tester);
-
-          final finder = find.byType(SortAction);
-          expect(finder, findsNothing);
-        },
-      );
-
-      testWidgets(
-        "given a todo list with one done item, "
+        "given todoState with showSortButton = false, "
         "when pumped, "
-        " then expects to find sort button",
+        "then not expects to find sort button",
         (tester) async {
-          final mockTodoItem0 = _MockTodoItem();
-          when(() => mockTodoItem0.done).thenReturn(true);
-          todoItems.add(mockTodoItem0);
+          when(() => initialTodoState.showSortButton).thenReturn(false);
 
-          final mockTodoItem1 = _MockTodoItem();
-          when(() => mockTodoItem1.done).thenReturn(false);
-          todoItems.add(mockTodoItem1);
+          await pumpTodoPage(tester);
+
+          final finder = find.byType(SortAction);
+          expect(finder, findsNothing);
+        },
+      );
+
+      testWidgets(
+        "given todoState with showSortButton = true, "
+        "when pumped, "
+        "then expects to find sort button",
+        (tester) async {
+          when(() => initialTodoState.showSortButton).thenReturn(true);
 
           await pumpTodoPage(tester);
 
@@ -95,57 +91,31 @@ void main() {
       );
 
       testWidgets(
-        "given a todo list with one undone item at first and a done item at second, "
-        "when sort button is clicked, "
-        "then expects to find done item at first on list",
+        "given todoState with showSortButton = true, "
+        "when sort action is tapped, "
+        "then expects to add TodoSortEvent to TodoBloc",
         (tester) async {
-          final notDoneTodoItem = _MockTodoItem();
-          when(() => notDoneTodoItem.done).thenReturn(false);
-          todoItems.add(notDoneTodoItem);
-
-          final doneTodoItem = _MockTodoItem();
-          when(() => doneTodoItem.done).thenReturn(true);
-          todoItems.add(doneTodoItem);
+          when(() => initialTodoState.showSortButton).thenReturn(true);
 
           await pumpTodoPage(tester);
 
           final finder = find.byType(SortAction);
           await tester.tap(finder);
 
-          expect(todoItems, [doneTodoItem, notDoneTodoItem]);
-        },
-      );
-
-      testWidgets(
-        "given a todo list with first item with done = true, "
-        "when sort button is clicked,"
-        " then expects to find done item at first on list",
-        (tester) async {
-          final doneTodoItem = _MockTodoItem();
-          when(() => doneTodoItem.done).thenReturn(true);
-          todoItems.add(doneTodoItem);
-
-          final notDoneTodoItem = _MockTodoItem();
-          when(() => notDoneTodoItem.done).thenReturn(false);
-          todoItems.add(notDoneTodoItem);
-
-          await pumpTodoPage(tester);
-
-          final finder = find.byType(SortAction);
-          await tester.tap(finder);
-
-          expect(todoItems, [doneTodoItem, notDoneTodoItem]);
+          verify(
+            () => todoBloc.add(TodoSortEvent()),
+          ).called(1);
         },
       );
     });
 
     group("CopyAction", () {
       testWidgets(
-        "given an empty todo list item, "
+        "given todoState with showCopyButton = false, "
         "when pumped, "
-        "then not expects to find copy button",
+        "then not expects to find CopyAction",
         (tester) async {
-          todoItems.clear();
+          when(() => initialTodoState.showCopyButton).thenReturn(false);
 
           await pumpTodoPage(tester);
 
@@ -155,48 +125,45 @@ void main() {
       );
 
       testWidgets(
-        "given one item not done and another done"
-        "when copy button is clicked, "
-        "then expects to call flutter/platform - Clipboard.setData' with formatted text",
+        "given todoState with showCopyButton = true, "
+        "when pumped, "
+        "then expects to find CopyAction",
         (tester) async {
-          String? result;
-          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-            const OptionalMethodChannel('flutter/platform', JSONMethodCodec()),
-            (message) async {
-              if (message.method == 'Clipboard.setData') {
-                result = message.arguments['text'];
-              }
-              return;
-            },
-          );
+          when(() => initialTodoState.showCopyButton).thenReturn(true);
 
-          final notDoneTodoItem = _MockTodoItem();
-          when(() => notDoneTodoItem.done).thenReturn(false);
-          when(() => notDoneTodoItem.description).thenReturn("not done");
-          todoItems.add(notDoneTodoItem);
+          await pumpTodoPage(tester);
 
-          final doneTodoItem = _MockTodoItem();
-          when(() => doneTodoItem.done).thenReturn(true);
-          when(() => doneTodoItem.description).thenReturn("done");
-          todoItems.add(doneTodoItem);
+          final finder = find.byType(CopyAction);
+          expect(finder, findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        "given todoState with showCopyButton = true, "
+        "when CopyAction is tapped, "
+        "then expects to add TodoCopyEvent to TodoBloc",
+        (tester) async {
+          when(() => initialTodoState.showCopyButton).thenReturn(true);
 
           await pumpTodoPage(tester);
 
           final finder = find.byType(CopyAction);
           await tester.tap(finder);
 
-          expect(result, "[ ] not done\n[X] done");
+          verify(
+            () => todoBloc.add(TodoCopyEvent()),
+          ).called(1);
         },
       );
     });
 
     group("DeleteAllAction", () {
       testWidgets(
-        "given an empty todo list item, "
+        "given todoState with showDeleteAllButton = false, "
         "when pumped, "
-        "then not expects to find delete all button",
+        "then not expects to find DeleteAllAction",
         (tester) async {
-          todoItems.clear();
+          when(() => initialTodoState.showDeleteAllButton).thenReturn(false);
 
           await pumpTodoPage(tester);
 
@@ -206,12 +173,25 @@ void main() {
       );
 
       testWidgets(
-        "given a todo list item, "
+        "given todoState with showDeleteAllButton = true, "
+        "when pumped, "
+        "then expects to find DeleteAllAction",
+        (tester) async {
+          when(() => initialTodoState.showDeleteAllButton).thenReturn(true);
+
+          await pumpTodoPage(tester);
+
+          final finder = find.byType(DeleteAllAction);
+          expect(finder, findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        "given todoState with showDeleteAllButton = true, "
         "when delete all button is clicked, "
         "then expects to find DeleteAllConfirmationDialog",
         (tester) async {
-          todoItems.add(_MockTodoItem());
-          todoItems.add(_MockTodoItem());
+          when(() => initialTodoState.showDeleteAllButton).thenReturn(true);
 
           await pumpTodoPage(tester);
 
@@ -225,17 +205,11 @@ void main() {
       );
 
       testWidgets(
-        "given a todo list item, "
+        "given todoState with showDeleteAllButton = true, "
         "when delete all button is clicked and then 'yes' button is clicked, "
-        "then expects to find the same items on the list",
+        "then expects to add TodoDeleteAllEvent to TodoBloc",
         (tester) async {
-          todoItems.add(_MockTodoItem());
-          todoItems.add(_MockTodoItem());
-          when(
-            () => localDataSource.saveTodoItems(todoItems),
-          ).thenAnswer((_) async {
-            return true;
-          });
+          when(() => initialTodoState.showDeleteAllButton).thenReturn(true);
 
           await pumpTodoPage(tester);
 
@@ -245,7 +219,9 @@ void main() {
 
           await DeleteAllConfirmationDialogTester.callOnPressed(tester);
 
-          expect(todoItems.isEmpty, isTrue);
+          verify(
+            () => todoBloc.add(TodoDeleteAllEvent()),
+          ).called(1);
         },
       );
     });
@@ -263,7 +239,7 @@ void main() {
         testWidgets(
           "given todo item with id = 0 at first position, "
           "when first item is reordered to second item, "
-          "then expects to find todo item with id = 0 at the second position",
+          "then expects to add TodoReorderEvent to TodoBloc",
           (tester) async {
             final todoItem0 = _MockTodoItem();
             when(() => todoItem0.id).thenReturn(0);
@@ -286,19 +262,21 @@ void main() {
 
             final todoItemWidget1Finder = find.byKey(const Key("todo-item-1"));
             await dragGesture
-                .moveTo(tester.getBottomLeft(todoItemWidget1Finder) * 2);
+                .moveTo(tester.getBottomLeft(todoItemWidget1Finder));
             await dragGesture.up();
 
             await tester.pumpAndSettle();
 
-            expect(todoItems, [todoItem1, todoItem0]);
+            verify(
+              () => todoBloc.add(TodoReorderEvent(oldIndex: 0, newIndex: 1)),
+            ).called(1);
           },
         );
 
         testWidgets(
           "given todo item with id = 1 at second position, "
           "when second item is reordered to first item, "
-          "then expects to find todo item with id = 1 at the first position",
+          "then expects to add TodoReorderEvent to TodoBloc",
           (tester) async {
             final todoItem0 = _MockTodoItem();
             when(() => todoItem0.id).thenReturn(0);
@@ -321,12 +299,14 @@ void main() {
 
             final todoItemWidget0Finder = find.byKey(const Key("todo-item-0"));
             await dragGesture
-                .moveTo(tester.getTopLeft(todoItemWidget0Finder) * -2);
+                .moveTo(tester.getTopLeft(todoItemWidget0Finder) * -1);
             await dragGesture.up();
 
             await tester.pumpAndSettle();
 
-            expect(todoItems, [todoItem1, todoItem0]);
+            verify(
+              () => todoBloc.add(TodoReorderEvent(oldIndex: 1, newIndex: 0)),
+            ).called(1);
           },
         );
       });
@@ -335,7 +315,7 @@ void main() {
         testWidgets(
           "given a todo list item, "
           "when first item is swiped to left, "
-          "then not expects to find this item on the list",
+          "then not expects to add TodoDismissedEvent to TodoBloc",
           (tester) async {
             final todoItem0 = _MockTodoItem();
             when(() => todoItem0.id).thenReturn(0);
@@ -356,14 +336,19 @@ void main() {
             );
             await tester.pumpAndSettle();
 
-            expect(todoItems, [todoItem1]);
+            verify(
+              () => todoBloc.add(TodoDismissedEvent(
+                index: 0,
+                todoItem: todoItem0,
+              )),
+            ).called(1);
           },
         );
 
         testWidgets(
           "given a todo list item, "
           "when first item is swiped to left and tapped on 'undo' of Snackbar, "
-          "then expects to find this item on the list yet",
+          "then not expects to add TodoUndoDismissedEvent to TodoBloc",
           (tester) async {
             final todoItem0 = _MockTodoItem();
             when(() => todoItem0.id).thenReturn(0);
@@ -387,6 +372,12 @@ void main() {
             await tester.tap(find.text("Undo"));
 
             expect(todoItems, [todoItem0, todoItem1]);
+            verify(
+              () => todoBloc.add(TodoUndoDismissedEvent(
+                index: 0,
+                todoItem: todoItem0,
+              )),
+            ).called(1);
           },
         );
       });
@@ -395,7 +386,7 @@ void main() {
         testWidgets(
           "given a todo list item with done = false, "
           "when checkbox of the item is tapped, "
-          "then expects to find item with done = true",
+          "then expects to add TodoDoneUpdateEvent to TodoBloc with done = true",
           (tester) async {
             const todoItem0 = TodoItem(
               id: 0,
@@ -409,15 +400,11 @@ void main() {
             await TodoItemWidgetTester.tapToChangeDone(tester);
 
             verify(
-              () => localDataSource.saveTodoItems(
-                const [
-                  TodoItem(
-                    id: 0,
-                    description: "",
-                    done: true,
-                  )
-                ],
-              ),
+              () => todoBloc.add(TodoDoneUpdateEvent(
+                index: 0,
+                todoItem: todoItem0,
+                newDoneValue: true,
+              )),
             ).called(1);
           },
         );
@@ -425,7 +412,7 @@ void main() {
         testWidgets(
           "given a todo list item with done = true, "
           "when checkbox of the item is tapped, "
-          "then expects to find item with done = false",
+          "then expects to add TodoDoneUpdateEvent to TodoBloc with done = false",
           (tester) async {
             const todoItem0 = TodoItem(
               id: 0,
@@ -439,15 +426,11 @@ void main() {
             await TodoItemWidgetTester.tapToChangeDone(tester);
 
             verify(
-              () => localDataSource.saveTodoItems(
-                const [
-                  TodoItem(
-                    id: 0,
-                    description: "",
-                    done: false,
-                  )
-                ],
-              ),
+              () => todoBloc.add(TodoDoneUpdateEvent(
+                index: 0,
+                todoItem: todoItem0,
+                newDoneValue: false,
+              )),
             ).called(1);
           },
         );
@@ -457,7 +440,7 @@ void main() {
         testWidgets(
           "given a todo list item, "
           "when text field is editted, "
-          "then expects to find item with updated description",
+          "then expects to add TodoDescriptionUpdateEvent to TodoBloc",
           (tester) async {
             const oldDescription = "mock description";
             const todoItem0 = TodoItem(
@@ -479,15 +462,11 @@ void main() {
             );
 
             verify(
-              () => localDataSource.saveTodoItems(
-                const [
-                  TodoItem(
-                    id: 0,
-                    description: newDescription,
-                    done: false,
-                  )
-                ],
-              ),
+              () => todoBloc.add(TodoDescriptionUpdateEvent(
+                index: 0,
+                todoItem: todoItem0,
+                newDescription: newDescription,
+              )),
             ).called(1);
           },
         );
@@ -496,9 +475,8 @@ void main() {
 
     group("AddFloatingActionButton", () {
       testWidgets(
-        "given a empty todo list, "
         "when floating action button is tapped, "
-        "then expects to find TodoItemWidget with a new TodoItem",
+        "then expects to add TodoAddItemEvent to TodoBloc",
         (tester) async {
           todoItems.clear();
 
@@ -506,107 +484,79 @@ void main() {
 
           await tester.tap(find.byType(AddFloatingActionButton));
           await tester.pumpAndSettle();
-
-          final finder = find.byType(TodoItemWidget);
-          final todoItemWidget = tester.widget(finder) as TodoItemWidget;
-          expect(todoItemWidget.todoItem.id, TodoItem.newItemId);
-          expect(todoItemWidget.todoItem.description, isNull);
-          expect(todoItemWidget.todoItem.done, isFalse);
-
-          await tester.pumpAndSettle();
-        },
-      );
-
-      testWidgets(
-        "given a empty todo list, "
-        "when floating action button is tapped, "
-        "then expects to find new item on todo items",
-        (tester) async {
-          todoItems.clear();
-
-          await pumpTodoPage(tester);
-
-          await tester.tap(find.byType(AddFloatingActionButton));
-          await tester.pumpAndSettle();
-
-          expect(todoItems.isNotEmpty, isTrue);
-          expect(todoItems.first.id, TodoItem.newItemId);
-
-          await tester.pumpAndSettle();
-        },
-      );
-
-      testWidgets(
-        "when floating action button is tapped, "
-        "then not call localDataSource.saveTodoItems",
-        (tester) async {
-          todoItems.clear();
-
-          await pumpTodoPage(tester);
-
-          await tester.tap(find.byType(AddFloatingActionButton));
-          await tester.pumpAndSettle();
-
-          registerFallbackValue(_FakeTodoItem());
-          verifyNever(() => localDataSource.saveTodoItems(captureAny()));
-
-          await tester.pumpAndSettle();
-        },
-      );
-
-      testWidgets(
-        "given an empty todo list, "
-        "when floating action button is tapped twice, "
-        "then expect to find one new item on the list",
-        (tester) async {
-          todoItems.clear();
-
-          await pumpTodoPage(tester);
-
-          await tester.tap(find.byType(AddFloatingActionButton));
-          await tester.tap(find.byType(AddFloatingActionButton));
-          await tester.pumpAndSettle();
-
-          expect(todoItems.length, 1);
-
-          await tester.pumpAndSettle();
-        },
-      );
-
-      testWidgets(
-        "given a empty todo list, "
-        "when floating action button is tapped and an text is entered to text field, "
-        "then expects to find the new item with a valid id",
-        (tester) async {
-          when(
-            () => localDataSource.saveTodoItems(captureAny()),
-          ).thenAnswer((_) async => true);
-          todoItems.clear();
-
-          await pumpTodoPage(tester);
-
-          await tester.tap(find.byType(AddFloatingActionButton));
-          await tester.pumpAndSettle();
-
-          const description = "mock description";
-          await tester.enterText(
-            TodoItemWidgetTester.getDescriptionField(),
-            description,
-          );
 
           verify(
-            () => localDataSource.saveTodoItems(
-              const [
-                TodoItem(
-                  id: 1,
-                  description: description,
-                  done: false,
-                )
-              ],
-            ),
+            () => todoBloc.add(TodoAddItemEvent()),
           ).called(1);
+        },
+      );
+    });
 
-          await tester.pumpAndSettle();
+    group("BlocListener", () {
+      late TodoState newStateEmitted;
+
+      setUp(() {
+        newStateEmitted = _MockTodoState();
+        when(() => newStateEmitted.lastAction).thenReturn(TodoAction.copied);
+        when(() => newStateEmitted.todoItems).thenReturn(todoItems);
+
+        whenListen(
+          todoBloc,
+          Stream<TodoState>.value(newStateEmitted),
+          initialState: initialTodoState,
+        );
+      });
+
+      testWidgets(
+        "when TodoBloc emits a TodoState with lastAction == TodoAction.copied, "
+        "then expects to call flutter/platform - Clipboard.setData' with formatted text",
+        (tester) async {
+          String? result;
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            const OptionalMethodChannel('flutter/platform', JSONMethodCodec()),
+            (message) async {
+              if (message.method == 'Clipboard.setData') {
+                result = message.arguments['text'];
+              }
+              return;
+            },
+          );
+
+          when(() => newStateEmitted.lastAction).thenReturn(TodoAction.copied);
+          const textCopied = "text copied";
+          when(() => newStateEmitted.textCopied).thenReturn(textCopied);
+
+          await pumpTodoPage(tester);
+
+          await tester.pump();
+
+          expect(result, textCopied);
+        },
+      );
+
+      testWidgets(
+        "when TodoBloc emits a TodoState with lastAction == TodoAction.newItem, "
+        "then expects to find focusNode of the last TodoItemWidget with focus",
+        (tester) async {
+          final fakeAsync = FakeAsync();
+          fakeAsync.run((async) async {
+            todoItems.add(_MockTodoItem());
+            when(() => newStateEmitted.lastAction)
+                .thenReturn(TodoAction.newItem);
+
+            await pumpTodoPage(tester);
+
+            await tester.pump();
+            async.elapse(const Duration(milliseconds: 500));
+
+            final lastTodoItemWidget = tester
+                .widgetList(
+                  find.byType(TodoItemWidget),
+                )
+                .last as TodoItemWidget;
+            expect(lastTodoItemWidget.focusNode?.hasFocus, isTrue);
+          });
+          fakeAsync.flushMicrotasks();
         },
       );
     });
@@ -623,4 +573,12 @@ class _MockTodoItem extends Mock implements TodoItem {
   }
 }
 
-class _FakeTodoItem extends Fake implements TodoItem {}
+class _MockTodoBloc extends Mock implements TodoBloc {}
+
+class _MockTodoState extends Mock implements TodoState {
+  _MockTodoState() {
+    when(() => showDeleteAllButton).thenReturn(false);
+    when(() => showSortButton).thenReturn(false);
+    when(() => showCopyButton).thenReturn(false);
+  }
+}

--- a/test/todo_page_test.dart
+++ b/test/todo_page_test.dart
@@ -29,7 +29,7 @@ void main() {
           primarySwatch: Colors.blue,
         ),
         home: TodoPage(
-          localDataSource: localDataSource,
+          _localDataSource: localDataSource,
         ),
       ),
     );


### PR DESCRIPTION
Adicionando o BLoC, o número de linhas do projeto aumentou consideravelmente, já que o boilerplate do BLoC é consideravelmente grande (inclusive na parte de testes). 

Porém, toda a parte da lógica de atualizar a lista de itens depois de uma determinada ação (reordenação, exclusão, adição, atualização...) foi retirada da `TodoPage` e portanto, deixando a parte muito mais simples.

Essa refatoração num cenário de apenas de _widget not-smarts_ envolveu apenas alguns arquivos já existentes: `todo_page.dart`, o `main.dart` e o `todo_page_test.dart`. Podemos considerar como um ponto positivo, já que todo o restante dos _widgets_ não precisaram ser adaptados.

Apesar dos testes não terem mudado tanto em número de linhas, os asserts dos testes mudaram bastante.
